### PR TITLE
Exclude scm providers dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId> org.apache.maven.scm</groupId>
+                    <artifactId>maven-scm-providers-standard</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
These are not use, and the OWASP Dependency check found a minor problem with it's transitive dependencies